### PR TITLE
速度超大提升，子集化模块从fontTools换成harfbuzz，loadFont到makeOneEmbedFontsText基本保持by…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ coloredlogs==15.0.1
 chardet==5.1.0
 colour-science==0.4.4
 numpy==1.26.4
+uharfbuzz==0.41.0

--- a/src/fontLoader.py
+++ b/src/fontLoader.py
@@ -134,7 +134,9 @@ def loadFont(fontName, externalFonts, fontPathMap, fontCache):
             for font in ttc.fonts:
                 for record in font["name"].names:
                     if record.nameID == 1 and str(record).strip() == fontName:
-                        fontCache[fontName] = fontBytes
+                        fontOutIO = BytesIO()
+                        font.save(fontOutIO)
+                        fontCache[fontName] = fontOutIO
                         return copy.deepcopy(fontCache[fontName])
 
         else:


### PR DESCRIPTION
之前把多线程换成多进程时候就发现loadFont先是一个bytes对象后返回一个TTFONT对象，然后经过fontTools子集化，再经过font.save转成bytes的时候，这个时间超久，字体文件越大越久。现在替换成harfbuzz来子集化，从loadFont到子集化基本全程bytes，速度提升明显。先上效果图。
1、无子集化效果：
![无子集化](https://github.com/user-attachments/assets/97cf54cc-433c-45d5-8ea2-490f58b38d81)
2、fontTools子集化效果与本机速度：
![原效果](https://github.com/user-attachments/assets/7cf976fb-41d8-40ba-bc5f-daf1dfc93289)
![原速度与大小](https://github.com/user-attachments/assets/a53beb1c-658c-4f0a-b276-6b3163eda36b)
3、harfbuzz子集化效果与本机速度：
![后效果](https://github.com/user-attachments/assets/176f0631-bfbb-4152-b07a-376c448cac96)
![后速度与大小](https://github.com/user-attachments/assets/75ac3b3e-0517-4f74-aa88-220511c42ddd)
4、最后是群晖下的速度测试：
fontTools：
![群晖原速度与大小](https://github.com/user-attachments/assets/20d3ea76-3217-44f3-b66c-2fb92286bc68)
harfbuzz：
![后群晖速度与大小](https://github.com/user-attachments/assets/2652bc9a-34f9-4114-9bfd-e122ace94ce7)

现在子集化速度提升后，我的800Mhz的群晖也是能用上这个了。本来是想把loadFont的ttc字体检测也换成harfbuzz完全脱离fontTools的，但是uharfbuzz没有文档看，参数全靠看源码，找了很久都没找到获取ttc index与name的，属实折磨。

最后是fontTools与harfbuzz单字体子集化速度对比，fontTools与harfbuzz子集化后生成的字体大小有所不同，不知道有没有影响。
```python
import logging
import time
from io import BytesIO

import uharfbuzz
from fontTools.subset import Subsetter
from fontTools.ttLib import TTFont
from src import assSubsetter

def fsub(font,unicodeSet):
    start = time.time()
    subsetter = Subsetter()
    subsetter.populate(unicodes=unicodeSet)
    subsetter.subset(font)
    fontOutIO = BytesIO()
    font.save(fontOutIO)
    data = fontOutIO.getvalue()
    enc = assSubsetter.uuencode(data)
    logger.error(
        f"用时 {(time.time() - start) * 1000:.2f} ms"
    )
    print(f"fontTools font size:  {len(data)}")
    print(f"fontTools enc:  {len(enc)}")
    # print(enc)

def usub(fontBytes,unicodeSet):
    start = time.time()
    face = uharfbuzz.Face(fontBytes)
    inp = uharfbuzz.SubsetInput()
    inp.sets(uharfbuzz.SubsetInputSets.UNICODE).set(unicodeSet)
    # inp.sets(hb.SubsetFlags.NO_HINTING | hb.SubsetFlags.RETAIN_GIDS | hb.SubsetFlags.DESUBROUTINIZE | hb.SubsetFlags.NAME_LEGACY | hb.SubsetFlags.SET_OVERLAPS_FLAG | hb.SubsetFlags.PASSTHROUGH_UNRECOGNIZED | hb.SubsetFlags.NOTDEF_OUTLINE | hb.SubsetFlags.GLYPH_NAMES | hb.SubsetFlags.NO_PRUNE_UNICODE_RANGES | hb.SubsetFlags.NO_LAYOUT_CLOSURE)
    # print(hb.SubsetFlags.NO_HINTING)
    face = uharfbuzz.subset(face, inp)
    data = face.blob.data
    enc = assSubsetter.uuencode(data)
    logger.error(
        f"用时 {(time.time() - start) * 1000:.2f} ms"
    )
    print(f"uharfbuzz font size:  {len(data)}")
    print(f"uharfbuzz enc:  {len(enc)}")
    # print(enc)

logger = logging.getLogger(f'{"main"}:{"loger"}')

filepath = "../fonts/收集字体/4123_方正准圆_GBK.TTF"
fontbytes = open(filepath, "rb").read()
unicodeSet= {35328, 29702, 32780, 19981, 21516, 25105, 30738, 35859, 23572, 26132, 21531, 19995, 24605, 20004, 27684, 33830, 33831, 28201, 21035, 33324, 20013, 26159, 29233, 27698, 20026, 21566, 34880, 27714, 26690, 20043, 34903, 34394, 20063, 29791, 24675, 25200, 20081, 33394, 21619, 33395, 21621, 31354, 27779, 30340, 30342, 24199, 32902, 31881, 38544, 26262, 39068, 25252, 20134, 36523, 26286, 33457, 33459, 32437, 25273, 20154, 21693, 38590, 33988, 30408, 21705, 20170, 39118, 32469, 33502, 28385, 23267, 33510, 28902, 32999, 27882, 29420, 30446, 24815, 22768, 24819, 29942, 30456, 32509, 21247, 32512, 22788, 21254, 24847, 31505, 21270, 29976, 38684, 22303, 24352, 26406, 26412, 22836, 28982, 25910, 22842, 25918, 21311, 24895, 21326, 20305, 27987, 20309, 26970, 38750, 35167, 20837, 22374, 33647, 39280, 24433, 34164, 28024, 33145, 24444, 24448, 22914, 22918, 23433, 32654, 23451, 26525, 23454, 33694, 25504, 23459, 22952, 33707, 33719, 23481, 35776, 26049, 24515, 35269, 34255, 37329, 26579, 26580, 31192, 20440, 35805, 26080, 26085, 24551, 21480, 26087, 33258, 35821, 36339, 38902, 23547, 36861, 23039}

bio = BytesIO()
bio.write(fontbytes)
font = TTFont(bio)
fsub(font,unicodeSet)
print("\n")
usub(fontbytes,unicodeSet)

```
![测试1](https://github.com/user-attachments/assets/ee137126-9174-4c1b-a8bf-ceb214532251)
