### PR TITLE
ttc字体读取速度大改进，loadFont读取ttc与ttf同样返回fontbytes与对应ttc位置的index，ttf默认返回0，去除…

### DIFF
--- a/src/assSubsetter.py
+++ b/src/assSubsetter.py
@@ -190,6 +190,30 @@ def makeEmbedFonts(pool, font_charList, externalFonts, fontPathMap, fontCache):
 
     return errors, embedFontsText
 
+# def makeOneEmbedFontsText(args):
+#     # 在每个子进程中设置日志，这亚子报错了在主进程也可以看到
+#     logging.basicConfig(level=logging.ERROR, format='%(asctime)s - %(levelname)s - %(message)s')
+#
+#     fontBytes, fontName, unicodeSet,= args
+#     if fontBytes is None:
+#         return f"{fontName} miss", None
+#     else:
+#         try:
+#             #转harfbuzz.Face对象
+#             face = uharfbuzz.Face(fontBytes)
+#             #初始化子集化UNICODE
+#             inp = uharfbuzz.SubsetInput()
+#             inp.sets(uharfbuzz.SubsetInputSets.UNICODE).set(unicodeSet)
+#             #子集化
+#             face = uharfbuzz.subset(face, inp)
+#             #编码，直接传入bytes类型face.blob.data
+#             enc = uuencode(face.blob.data)
+#             return None, f"fontname:{fontName}_0.ttf\n{enc}\n"
+#         except Exception as e:
+#             logger.error(f"子集化{fontName}出错 : \n{traceback.format_exc()}")
+#             return f" {fontName} : {str(e)}", None
+
+
 def makeOneEmbedFontsText(args):
     # 在每个子进程中设置日志，这亚子报错了在主进程也可以看到
     logging.basicConfig(level=logging.ERROR, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -199,8 +223,9 @@ def makeOneEmbedFontsText(args):
         return f"{fontName} miss", None
     else:
         try:
-            #转harfbuzz.Face对象
-            face = uharfbuzz.Face(fontBytes)
+            # logger.error(f"当前字体处于ttc的index : {fontBytes[1]}")
+            #转harfbuzz.Face对象 指定blob的faces_index
+            face = uharfbuzz.Face(fontBytes[0],fontBytes[1])
             #初始化子集化UNICODE
             inp = uharfbuzz.SubsetInput()
             inp.sets(uharfbuzz.SubsetInputSets.UNICODE).set(unicodeSet)
@@ -208,6 +233,7 @@ def makeOneEmbedFontsText(args):
             face = uharfbuzz.subset(face, inp)
             #编码，直接传入bytes类型face.blob.data
             enc = uuencode(face.blob.data)
+            del face
             return None, f"fontname:{fontName}_0.ttf\n{enc}\n"
         except Exception as e:
             logger.error(f"子集化{fontName}出错 : \n{traceback.format_exc()}")

--- a/src/fontLoader.py
+++ b/src/fontLoader.py
@@ -92,6 +92,61 @@ def makeFontMap(data):
 #         logger.error(f"加载字体出错 {fontName} : \n{traceback.format_exc()}")
 #         return None
 
+# @utils.printPerformance
+# def loadFont(fontName, externalFonts, fontPathMap, fontCache):
+#     cachedResult = fontCache.get(fontName)
+#     if cachedResult:
+#         logger.info(f"{fontName} 字体缓存命中")
+#         return copy.deepcopy(cachedResult)
+#
+#     try:
+#         if fontName in externalFonts:
+#             path = externalFonts[fontName]
+#             logger.info(f"从本地加载字体 {path}")
+#             if path.lower().startswith("http"):
+#                 fontBytes = requests.get(path).content
+#             else:
+#                 fontBytes = open(path, "rb").read()
+#         elif fontName in fontPathMap:
+#             path = fontPathMap[fontName]
+#             logger.info(f"从网络加载字体 https://fonts.storage.rd5isto.org{path}")
+#             fontBytes = requests.get(
+#                 "https://fonts.storage.rd5isto.org" + path
+#             ).content
+#
+#             # 构造完整的本地路径
+#             file_path = os.path.join("../fonts/download", path.lstrip('/'))
+#             # 确保路径中的文件夹存在
+#             local_path = os.path.dirname(file_path)
+#             os.makedirs(local_path, exist_ok=True)
+#             # 保存到本地
+#             with open(file_path, "wb") as f:
+#                 f.write(fontBytes)
+#             logger.info(f"字体已下载到本地 {file_path}")
+#         else:
+#             return None
+#
+#         if fontBytes[:4] == b"ttcf":
+#             fontInIO = BytesIO(fontBytes)
+#
+#             ttc = TTCollection(fontInIO)
+#             for font in ttc.fonts:
+#                 for record in font["name"].names:
+#                     if record.nameID == 1 and str(record).strip() == fontName:
+#                         fontOutIO = BytesIO()
+#                         #font.save好慢
+#                         font.save(fontOutIO)
+#                         fontCache[fontName] = fontOutIO.getvalue()
+#                         return copy.deepcopy(fontCache[fontName])
+#
+#         else:
+#             fontCache[fontName] = fontBytes
+#             return copy.deepcopy(fontCache[fontName])
+#     except Exception as e:
+#         logger.error(f"加载字体出错 {fontName} : \n{traceback.format_exc()}")
+#         return None
+
+
 @utils.printPerformance
 def loadFont(fontName, externalFonts, fontPathMap, fontCache):
     cachedResult = fontCache.get(fontName)
@@ -128,19 +183,14 @@ def loadFont(fontName, externalFonts, fontPathMap, fontCache):
 
         if fontBytes[:4] == b"ttcf":
             fontInIO = BytesIO(fontBytes)
-
             ttc = TTCollection(fontInIO)
-            for font in ttc.fonts:
+            for index, font in enumerate(ttc.fonts):
                 for record in font["name"].names:
                     if record.nameID == 1 and str(record).strip() == fontName:
-                        fontOutIO = BytesIO()
-                        #font.save好慢
-                        font.save(fontOutIO)
-                        fontCache[fontName] = fontOutIO.getvalue()
+                        fontCache[fontName] = [fontBytes, index]
                         return copy.deepcopy(fontCache[fontName])
-
         else:
-            fontCache[fontName] = fontBytes
+            fontCache[fontName] = [fontBytes,0]
             return copy.deepcopy(fontCache[fontName])
     except Exception as e:
         logger.error(f"加载字体出错 {fontName} : \n{traceback.format_exc()}")


### PR DESCRIPTION
之前看harfbuzz的文档face就有说到可以指定index引用多个不同face，但是在使用face = uharfbuzz.Face(fontBytes,index)时候，输出不同face.blob.data的长度与bytes数据基本一样，所以就以为怎么设定index都是读取0 index的ttf，结果测试下来发现uharfbuzz同样也可以指定index，并且生效。
然后我改了下字幕文件，指定一个ttc后面位置的字体，并且设定字体添加明显不同的文字测试。

首先是没有子集化效果的：

![无子集化效果](https://github.com/user-attachments/assets/3ce42aef-c52f-4596-a7c8-830e96b92a9a)
![无子集化效果放大](https://github.com/user-attachments/assets/4be23a06-5f33-4e90-880c-cb4afa789f04)

然后是字体信息与设置的样式：

![J](https://github.com/user-attachments/assets/740fc87f-7f66-4580-aac4-f9c2b61a7436)
![K](https://github.com/user-attachments/assets/c51c3baf-56a8-4448-a11a-01a0651b7e9d)
![改变字体index 3 4](https://github.com/user-attachments/assets/afd4949a-c4c4-43c4-b5a1-3bc2017f4acc)

然后是子集化后的效果：

![子集化效果](https://github.com/user-attachments/assets/9f280c9b-5581-43e4-89eb-f31795e9bb55)
![子集化效果放大](https://github.com/user-attachments/assets/6ac07dea-2eb4-4e28-b1e3-fd949d0b3681)

可以很明显看到字体已经生效，与字体信息里面的字体一致。

最后是上一个版本读取ttc文件与现在的速度对比

font.save版本：
![源代码速度](https://github.com/user-attachments/assets/cf56f0f6-cb48-4e55-8c1e-2aeb2f621ec2)

现在版本：
![新速度](https://github.com/user-attachments/assets/79e526a1-f47b-43f3-ba92-8141616073ad)


