### PR TITLE
perfect: 简化获取每行字幕的样式和文本的方法

### DIFF
--- a/src/analyseAss.py
+++ b/src/analyseAss.py
@@ -65,17 +65,9 @@ def analyseAss(ass_str: str):
             # print(styleItalic)
         elif state == 4:
             if line.startswith("Dialogue:"):
-                index = -1
-                for i in range(eventTextindex):
-                    index = line.find(",", index + 1)
-                    if i == eventStyleIndex - 1:
-                        styleStart = index
-                    elif i == eventStyleIndex:
-                        styleEnd = index
-                    elif i == eventTextindex - 1:
-                        textStart = index
-                styleName = line[styleStart + 1 : styleEnd].replace("*", "")
-                eventText = line[textStart + 1 :]
+                parts = line.replace("Dialogue:","").split(",")
+                styleName = parts[eventStyleIndex].replace("*", "")
+                eventText = ",".join(parts[eventTextindex:])
                 logger.debug(f"")
                 logger.debug(f"原始文本 : {eventText}")
 


### PR DESCRIPTION
修改了逻辑，考虑了台词中有英文逗号的情况：
```
Python 3.12.8 (tags/v3.12.8:2dc476b, Dec  3 2024, 19:30:04) [MSC v.1942 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> line = "Dialogue: 0,0:00:48.42,0:00:53.17,Default,,0,0,0,,这是一个没有英文逗号的台词"
>>> parts = line.replace("Dialogue:","").split(",")
>>> parts
[' 0', '0:00:48.42', '0:00:53.17', 'Default', '', '0', '0', '0', '', '这是一个没有英文逗号的台词']
>>> ",".join(parts[9:])
'这是一个没有英文逗号的台词'
>>> line = "Dialogue: 0,0:00:48.42,0:00:53.17,Default,,0,0,0,,这是一句有英文逗号,的台词"
>>> parts = line.replace("Dialogue:","").split(",")
>>> parts
[' 0', '0:00:48.42', '0:00:53.17', 'Default', '', '0', '0', '0', '', '这是一句有英文逗号', '的台词']
>>> ",".join(parts[9:])
'这是一句有英文逗号,的台词'
```