### PR TITLE
编译cpython时使用文件的相对路径进行查找

### DIFF
--- a/src/py2cy/setup.py
+++ b/src/py2cy/setup.py
@@ -1,9 +1,12 @@
+import platform
+from pathlib import Path
+
 from setuptools import setup
 from Cython.Build import cythonize
-import platform
+
 
 # 根据平台设置扩展名
-ext_modules = cythonize("c_utils.pyx")
+ext_modules = cythonize((Path(__file__).parent / "c_utils.pyx").as_posix())
 
 if platform.system() == "Windows":
     # Windows 上生成 .pyd 文件
@@ -14,8 +17,6 @@ elif platform.system() == "Linux" or platform.system() == "Darwin":
 else:
     pass
 
-setup(
-    ext_modules=ext_modules
-)
+setup(ext_modules=ext_modules)
 
-#命令行运行 python setup.py build_ext --inplace
+# 命令行运行 python setup.py build_ext --inplace

--- a/src/py2cy/setup.py
+++ b/src/py2cy/setup.py
@@ -4,9 +4,10 @@ from pathlib import Path
 from setuptools import setup
 from Cython.Build import cythonize
 
+file_dir = Path(__file__).parent
 
 # 根据平台设置扩展名
-ext_modules = cythonize((Path(__file__).parent / "c_utils.pyx").as_posix())
+ext_modules = cythonize((file_dir / "c_utils.pyx").as_posix())
 
 if platform.system() == "Windows":
     # Windows 上生成 .pyd 文件
@@ -17,6 +18,9 @@ elif platform.system() == "Linux" or platform.system() == "Darwin":
 else:
     pass
 
-setup(ext_modules=ext_modules)
+setup(
+    ext_modules=ext_modules,
+    script_args=["build_ext", "--inplace", "--build-lib", file_dir.as_posix()],
+)
 
 # 命令行运行 python setup.py build_ext --inplace


### PR DESCRIPTION
这样就不需要先进入`src/py2cy`目录再运行`setup.py`了
直接在项目根目录运行`python src\py2cy\setup.py  build_ext --inplace`即可