### PR TITLE
改进uuencode编码速度

### DIFF
--- a/src/py2cy/c_utils.pyx
+++ b/src/py2cy/c_utils.pyx
@@ -5,8 +5,9 @@ from typing import Dict, Optional, Set, Tuple
 def uuencode(const unsigned char[:] binaryData):
     """
     编码工具 (Cython实现)
+    https://en.wikipedia.org/wiki/Uuencoding
     """
-    cdef int OFFSET = 33
+    #cdef int OFFSET = 33
     cdef int CHUNK_SIZE = 20
     cdef int data_len = len(binaryData)
     cdef int remainder = data_len % 3
@@ -14,48 +15,35 @@ def uuencode(const unsigned char[:] binaryData):
     cdef list encoded_lines = []
     cdef int packed, i
     cdef int six_bits[4]
-    cdef str encoded_group
-
-    # 提前生成字符映射数组，避免重复调用 chr()
-    cdef bytes chr_map = bytes([OFFSET + i for i in range(64)])  # 用 bytes 存储映射字符
+    #cdef list chr_map = [chr(OFFSET + i) for i in range(64)]  # 提前生成字符映射为字符串
+    cdef list chr_map = ['!', '"', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '-', '.', '/', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ':', ';', '<', '=', '>', '?', '@', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '[', '\\', ']', '^', '_', '`']
 
     # 遍历 3 字节一组的块
     cdef int index = 0
-    for i in range(0, (data_len // 3) * 3, 3):
+    for i in range(0, data_len - remainder, 3):
         packed = (binaryData[i] << 16) | (binaryData[i + 1] << 8) | binaryData[i + 2]
         six_bits[0] = (packed >> 18) & 0x3F
         six_bits[1] = (packed >> 12) & 0x3F
         six_bits[2] = (packed >> 6) & 0x3F
         six_bits[3] = packed & 0x3F
-        encoded_group = (
-            chr_map[six_bits[0]:six_bits[0] + 1].decode() +
-            chr_map[six_bits[1]:six_bits[1] + 1].decode() +
-            chr_map[six_bits[2]:six_bits[2] + 1].decode() +
-            chr_map[six_bits[3]:six_bits[3] + 1].decode()
-        )
-        encoded[index] = encoded_group
+        encoded[index] = "".join([chr_map[six_bits[j]] for j in range(4)])
         index += 1
-
-    # 处理不满 3 字节的情况
+    # 处理不足 3 字节的情况
     if remainder == 1:
-        packed = binaryData[-1] << 16  # 将末尾单字节左移到24位
+        packed = binaryData[-1] << 16
+        #packed = binaryData[-1] * 0x100
         six_bits[0] = (packed >> 18) & 0x3F
         six_bits[1] = (packed >> 12) & 0x3F
-        encoded_group = chr_map[six_bits[0]:six_bits[0] + 1].decode() + chr_map[six_bits[1]:six_bits[1] + 1].decode()
-        encoded[index] = encoded_group
+        encoded[index] = chr_map[six_bits[0]] + chr_map[six_bits[1]]
     elif remainder == 2:
-        packed = (binaryData[-2] << 16) | (binaryData[-1] << 8)  # 将末尾双字节左移到24位
+        packed = (binaryData[-2] << 16) | (binaryData[-1] << 8)
+        #packed = ((binaryData[-2] << 8) | binaryData[-1]) * 0x10000
         six_bits[0] = (packed >> 18) & 0x3F
         six_bits[1] = (packed >> 12) & 0x3F
         six_bits[2] = (packed >> 6) & 0x3F
-        encoded_group = (
-            chr_map[six_bits[0]:six_bits[0] + 1].decode() +
-            chr_map[six_bits[1]:six_bits[1] + 1].decode() +
-            chr_map[six_bits[2]:six_bits[2] + 1].decode()
-        )
-        encoded[index] = encoded_group
+        encoded[index] = "".join([chr_map[six_bits[j]] for j in range(3)])
 
-    # 分行显示
+    # 分行显示 80字符一行
     cdef int num_chunks = (index + CHUNK_SIZE - 1) // CHUNK_SIZE  # 计算块数
     for i in range(num_chunks):
         encoded_lines.append("".join(encoded[i * CHUNK_SIZE:(i + 1) * CHUNK_SIZE]))


### PR DESCRIPTION
```python
🤖 23:20:01.320 .INFO 	字幕URL: http://127.0.0.1:8096/emby/Videos/8/16f568df36c17d574a13ba5173e303e5/Subtitles/3/0/Stream.ass?api_key=038e0928881b462caad990cc3b2cfcda
🤖 23:20:01.329 .INFO 	本地 16.38MB 0.16ms 	[('hyxuansong 35s', 400, False) <== C:/Users/Administrator/Desktop/py/fontInAss/fonts/收集字体/HYXuanSong35S.ttf]
🤖 23:20:01.332 .INFO 	uuencode耗时 2.72ms 	[HYXuanSong 35S]
🤖 23:20:01.334 .INFO 	uuencode_new耗时 1.36ms 	[HYXuanSong 35S]
🤖 23:20:01.335 .INFO 	本地 16.46MB 0.14ms 	[('hyxuansong 65s', 400, False) <== C:/Users/Administrator/Desktop/py/fontInAss/fonts/收集字体/HYXuanSong65S.ttf]
🤖 23:20:01.349 .INFO 	uuencode耗时 9.21ms 	[HYXuanSong 65S]
🤖 23:20:01.355 .INFO 	uuencode_new耗时 5.92ms 	[HYXuanSong 65S]
🤖 23:20:01.356 .INFO 	本地 16.36MB 0.13ms 	[('hyxuansong 55s', 400, False) <== C:/Users/Administrator/Desktop/py/fontInAss/fonts/收集字体/HYXuanSong55S.ttf]
🤖 23:20:01.356 .INFO 	uuencode耗时 0.18ms 	[HYXuanSong 55S]
🤖 23:20:01.357 .INFO 	uuencode_new耗时 0.12ms 	[HYXuanSong 55S]
🤖 23:20:01.357 .ERROR 	字体缺失 		[FOT-TsukuCOldMin Pr6N L]
🤖 23:20:01.358 .INFO 	本地 12.72MB 0.13ms 	[('fot-tsukuaoldmin pr6n e', 400, False) <== C:/Users/Administrator/Desktop/py/fontInAss/fonts/Fontworks/日文/明朝体（宋体）/FOT-TsukuAOldMinPr6N-E.otf]
🤖 23:20:01.374 .INFO 	uuencode耗时 10.31ms 	[FOT-TsukuAOldMin Pr6N E]
🤖 23:20:01.380 .INFO 	uuencode_new耗时 6.28ms 	[FOT-TsukuAOldMin Pr6N E]
🤖 23:20:01.380 .INFO 	ass分析 1.87ms
🤖 23:20:01.380 .INFO 	子集化嵌入 53.81ms
🤖 23:20:01.381 .ERROR 	存在错误，未缓存
🤖 23:20:01.381 .ERROR 	字体缺失 		[FOT-TsukuCOldMin Pr6N L]
🤖 23:20:01.381 .INFO 	字幕处理完成: 0.06MB ==> 0.87MB
🌏 23:20:01.382 .INFO 	127.0.0.1:63426 - "GET /emby/Videos/8/16f568df36c17d574a13ba5173e303e5/Subtitles/3/0/Stream.ass?api_key=038e0928881b462caad990cc3b2cfcda HTTP/1.0" 200
```