### PR TITLE
在原字幕中检测到 Font Subset 注释时也跳过字幕处理

### DIFF
--- a/src/assSubsetter.py
+++ b/src/assSubsetter.py
@@ -83,6 +83,10 @@ class assSubsetter:
         if "[Fonts]\n" in assText:
             logger.error("已有内嵌字体")
             return ("已有内嵌字体", False, subtitleBytes)
+        
+        if "Font Subset" in assText:
+            logger.info("已有内封字体子集")
+            return ("已有内封字体子集", False, subtitleBytes)
 
         if user_hsv_s == 1 and user_hsv_v == 1:
             pass


### PR DESCRIPTION
目前很多字幕组在发当季番剧的时候，都会在 mkv 里一并封装已经子集化处理好的字体。这种字幕不需要处理也可以在 Jellyfin 的前端正常渲染。（Emby 未测试，但肯定也是可以的）

这些已经封装子集字体的字幕会在 ass 的最前面有注释：

```
[Script Info]
; Font Subset: JIX8W9RS - UDDigiKyokasho StdN B
; Font Subset: RTCZKFNO - Tensentype JiaLiDaYuanGB18030
; Font Subset: VKP8L9NG - HYXiaoBoNuanSong W
; Font Subset: OE1IS470 - FZLanTingYuan-R-GBK
; Font Subset: AEPWPFUE - FZLanTingYuan-DB-GBK
; Font Subset: EEOX3F13 - FOT-UDMarugo_Large Pr6N B
; Font Subset: 1QK9Q3FH - DFYanKaiW7-GB
; Font Subset: F11Y28C1 - DFYanKaiW7-B5
; Font Subset: 995OM4OJ - DFHannotateW7-A
Title: [Nekomoe kissaten] Hibi wa Sugiredo Meshi Umashi [02][WebRip].JPSC
ScriptType: v4.00+
WrapStyle: 2
ScaledBorderAndShadow: yes
YCbCr Matrix: TV.709
PlayResX: 1920
PlayResY: 1080
LayoutResX: 1920
LayoutResY: 1080
```

所以通过判断原字幕里是否有 `Font Subset` 的注释，就可以知道当前视频是不是已经封装了字体子集的视频。如果是的话就直接跳过处理返回原字幕。